### PR TITLE
hotfix: Fix issue with load_ext

### DIFF
--- a/src/challenge.ipynb
+++ b/src/challenge.ipynb
@@ -9,26 +9,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%load_ext autoreload\n",
+    "%reload_ext autoreload\n",
     "%autoreload 2"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
The notebook had load_ext for the automatic reload feature. However the correct command is reload_ext