### PR TITLE
feat: Spark required libraries and Jupyter Kernel pip versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-memory-profiler==0.61.0  # Librería para perfilamiento de memoria
-ipython==8.23.0  # Consola interactiva avanzada para Python
+memory-profiler==0.61.0 # Librería para perfilamiento de memoria
+ipython==8.18.1         # Consola interactiva avanzada para Python
+findspark==1.4.2        # Biblioteca para agregar la instalación de Spark al PYTHONPATH en Python.
+pyspark==3.0.2          # Biblioteca principal para interactuar con Spark desde Python, incluida la creación de sesiones Spark y la manipulación de datos en Spark DataFrames.
+py4j==0.10.9            # Librería de conexión entre Python y Java


### PR DESCRIPTION
Changed ipython version available in Jupyter kernel Added findspark to detect spark and java path folders Added py4j 0.10.9 from jupyter kernel
Added pyspark 3.0.2 compatible with py4j 0.10.9